### PR TITLE
(DI-92) Pass JSON string by pointer, sanitise methods and add godocs.

### DIFF
--- a/go_wrapper/libral.go
+++ b/go_wrapper/libral.go
@@ -14,7 +14,35 @@ import (
 	"unsafe"
 )
 
-// GetTypes TODO
+// GetProviders returns a JSON string containing a list of providers known to libral.
+//
+// For example:
+//
+//   {
+//       "providers": [
+//           {
+//               "name": "file::posix",
+//               "type": "file",
+//               "source": "builtin",
+//               "desc": "A provider to manage POSIX files.\n",
+//               "suitable": true,
+//               "attributes": [
+//                   {
+//                       "name": "checksum",
+//                       "desc": "(missing description)",
+//                       "type": "enum[md5, md5lite, sha256, sha256lite, mtime, ctime, none]",
+//                       "kind": "r"
+//                   },
+//                   ...
+//               ]
+//           },
+//           {
+//               "name": "host::aug",
+//               "type": "host",
+//               ...
+//           }
+//       ]
+//   }
 func GetProviders() (string, error) {
 	var resultC *C.char
 	defer C.free(unsafe.Pointer(resultC))
@@ -27,7 +55,35 @@ func GetProviders() (string, error) {
 	return result, nil
 }
 
-// GetResources TODO
+// GetResources returns a JSON string containing a list all resources of the specified type
+// found by libral.
+//
+// For example, querying the `host` type:
+//
+//   {
+//       "resources": [
+//           {
+//               "name": "localhost",
+//               "ensure": "present",
+//               "ip": "127.0.0.1",
+//               "target": "/etc/hosts",
+//               "ral": {
+//                   "type": "host",
+//                   "provider": "host::aug"
+//               }
+//           },
+//           {
+//               "name": "broadcasthost",
+//               "ensure": "present",
+//               "ip": "255.255.255.255",
+//               "target": "/etc/hosts",
+//               "ral": {
+//                   "type": "host",
+//                   "provider": "host::aug"
+//               }
+//           }
+//       ]
+//   }
 func GetResources(typeName string) (string, error) {
 	var resultC *C.char
 	defer C.free(unsafe.Pointer(resultC))
@@ -42,7 +98,25 @@ func GetResources(typeName string) (string, error) {
 	return result, nil
 }
 
-// GetResource TODO
+// GetResource returns a JSON string containing the matching resources of the specified type
+// found by libral. It will throw an error if multiple resources are found with the same name.
+//
+// For example, querying the `host` type `broadcasthost`:
+//
+//   {
+//       "resources": [
+//           {
+//               "name": "broadcasthost",
+//               "ensure": "present",
+//               "ip": "255.255.255.255",
+//               "target": "/etc/hosts",
+//               "ral": {
+//                   "type": "host",
+//                   "provider": "host::aug"
+//               }
+//           }
+//       ]
+//   }
 func GetResource(typeName, resourceName string) (string, error) {
 	var resultC *C.char
 	defer C.free(unsafe.Pointer(resultC))

--- a/go_wrapper/libral.go
+++ b/go_wrapper/libral.go
@@ -1,8 +1,8 @@
 package libral
 
 /*
-#cgo LDFLAGS: -L/Users/john.mccabe/workspaces/github/libral/build/lib -lral -lstdc++ /usr/local/lib/leatherman_json_container.a /usr/local/lib/leatherman_execution.a /usr/local/lib/leatherman_logging.a /usr/local/lib/leatherman_locale.a /usr/local/lib/libboost_locale-mt.dylib /usr/local/lib/libboost_system-mt.dylib /usr/local/lib/libboost_log-mt.dylib /usr/local/lib/libboost_log_setup-mt.dylib /usr/local/lib/libboost_thread-mt.dylib /usr/local/lib/libboost_date_time-mt.dylib /usr/local/lib/libboost_filesystem-mt.dylib /usr/local/lib/libboost_chrono-mt.dylib /usr/local/lib/libboost_regex-mt.dylib /usr/local/lib/libboost_atomic-mt.dylib /usr/local/lib/leatherman_util.a /usr/local/lib/leatherman_file_util.a /usr/local/lib/libyaml-cpp.dylib /usr/local/lib/libboost_program_options-mt.dylib /usr/local/lib/libaugeas.dylib
-#cgo CFLAGS: -I/Users/john.mccabe/workspaces/github/libral/lib/inc
+#cgo LDFLAGS: -L${SRCDIR}/../build/lib -lral -lstdc++ /usr/local/lib/leatherman_json_container.a /usr/local/lib/leatherman_execution.a /usr/local/lib/leatherman_logging.a /usr/local/lib/leatherman_locale.a /usr/local/lib/libboost_locale-mt.dylib /usr/local/lib/libboost_system-mt.dylib /usr/local/lib/libboost_log-mt.dylib /usr/local/lib/libboost_log_setup-mt.dylib /usr/local/lib/libboost_thread-mt.dylib /usr/local/lib/libboost_date_time-mt.dylib /usr/local/lib/libboost_filesystem-mt.dylib /usr/local/lib/libboost_chrono-mt.dylib /usr/local/lib/libboost_regex-mt.dylib /usr/local/lib/libboost_atomic-mt.dylib /usr/local/lib/leatherman_util.a /usr/local/lib/leatherman_file_util.a /usr/local/lib/libyaml-cpp.dylib /usr/local/lib/libboost_program_options-mt.dylib /usr/local/lib/libaugeas.dylib
+#cgo CFLAGS: -I${SRCDIR}/../lib/inc
 
 #include "libral/cwrapper.hpp"
 #include <stdlib.h>

--- a/go_wrapper/libral.go
+++ b/go_wrapper/libral.go
@@ -1,76 +1,60 @@
 package libral
 
 /*
-#cgo LDFLAGS: -L/Users/alessandro/code/libral/build/lib -lral -lstdc++ /usr/local/lib/leatherman_json_container.a /usr/local/lib/leatherman_execution.a /usr/local/lib/leatherman_logging.a /usr/local/lib/leatherman_locale.a /usr/local/lib/libboost_locale-mt.dylib /usr/local/lib/libboost_system-mt.dylib /usr/local/lib/libboost_log-mt.dylib /usr/local/lib/libboost_log_setup-mt.dylib /usr/local/lib/libboost_thread-mt.dylib /usr/local/lib/libboost_date_time-mt.dylib /usr/local/lib/libboost_filesystem-mt.dylib /usr/local/lib/libboost_chrono-mt.dylib /usr/local/lib/libboost_regex-mt.dylib /usr/local/lib/libboost_atomic-mt.dylib /usr/local/lib/leatherman_util.a /usr/local/lib/leatherman_file_util.a /usr/local/lib/libyaml-cpp.dylib /usr/local/lib/libboost_program_options-mt.dylib /usr/local/lib/libaugeas.dylib
-#cgo CFLAGS: -I/Users/alessandro/code/libral/lib/inc
+#cgo LDFLAGS: -L/Users/john.mccabe/workspaces/github/libral/build/lib -lral -lstdc++ /usr/local/lib/leatherman_json_container.a /usr/local/lib/leatherman_execution.a /usr/local/lib/leatherman_logging.a /usr/local/lib/leatherman_locale.a /usr/local/lib/libboost_locale-mt.dylib /usr/local/lib/libboost_system-mt.dylib /usr/local/lib/libboost_log-mt.dylib /usr/local/lib/libboost_log_setup-mt.dylib /usr/local/lib/libboost_thread-mt.dylib /usr/local/lib/libboost_date_time-mt.dylib /usr/local/lib/libboost_filesystem-mt.dylib /usr/local/lib/libboost_chrono-mt.dylib /usr/local/lib/libboost_regex-mt.dylib /usr/local/lib/libboost_atomic-mt.dylib /usr/local/lib/leatherman_util.a /usr/local/lib/leatherman_file_util.a /usr/local/lib/libyaml-cpp.dylib /usr/local/lib/libboost_program_options-mt.dylib /usr/local/lib/libaugeas.dylib
+#cgo CFLAGS: -I/Users/john.mccabe/workspaces/github/libral/lib/inc
 
 #include "libral/cwrapper.hpp"
-
-// extern char* get_all(char* type_name_c);
-// extern uint8_t get_all_with_err(char** resource, char* type_name);
-// extern outcome get_all_outcome(char* type_name_c);
+#include <stdlib.h>
 */
 import "C"
 
-import "fmt"
+import (
+	"fmt"
+	"unsafe"
+)
 
-//"unsafe"
+// GetTypes TODO
+func GetProviders() (string, error) {
+	var resultC *C.char
+	defer C.free(unsafe.Pointer(resultC))
 
-// Outcome TODO
-type Outcome struct {
-	Result    string
-	ErrorCode int
-}
-
-// OutcomeC TODO
-// type OutcomeC C.struct_outcome
-
-func convertOutcome(in C.struct_outcome) Outcome {
-	out := new(Outcome)
-	out.Result = C.GoString(in.result)
-	out.ErrorCode = int(in.error_code)
-	//newout := Outcome{
-	//	Result: C.GoString(in.result),
-	//	ErrorCode: int(in.error_code),
-	//}
-	return *out
-}
-
-// GetAllOutcome TODO
-func GetAllOutcome(typeName string) (string, error) {
-	typeNameC := C.CString(typeName)
-	// defer C.free(unsafe.Pointer(typeNameC))
-	outC := C.get_all_outcome(typeNameC)
-	out := convertOutcome(outC)
-	if out.ErrorCode != 0 {
-		return "", fmt.Errorf("Error thrown calling native get_all_outcome: %d", out.ErrorCode)
+	ok := C.get_providers(&resultC)
+	if ok != 0 {
+		return "", fmt.Errorf("Error thrown calling get_providers: %d", ok)
 	}
-	return out.Result, nil
+	result := C.GoString(resultC)
+	return result, nil
 }
 
-// GetAll invokes the get_all(type_name) function in the wrapped libral
-// library converting the output from a char* to native golang string
-func GetAll(typeName string) string {
-	var hosts string
+// GetResources TODO
+func GetResources(typeName string) (string, error) {
+	var resultC *C.char
+	defer C.free(unsafe.Pointer(resultC))
 	typeNameC := C.CString(typeName)
-	// defer C.free(unsafe.Pointer(typeNameC))
-	hosts = C.GoString(C.get_all(typeNameC))
-	return hosts
+	defer C.free(unsafe.Pointer(typeNameC))
+
+	ok := C.get_resources(&resultC, typeNameC)
+	if ok != 0 {
+		return "", fmt.Errorf("Error thrown calling get_all_resources: %d", ok)
+	}
+	result := C.GoString(resultC)
+	return result, nil
 }
 
-// GetAll invokes the get_all_with_err(&resource, type_name) function in
-// the wrapped libral
-// func GetAllWithErr(typeName string) (string, error) {
-// 	//var resources string
-// 	var r *C.char
-// 	var resources unsafe.Pointer(r)
-// 	defer C.Free(resources)
-// 	var err error
-// 	errorCode := C.get_all_with_err(r, C.CString(typeName))
-// 	if errorCode != 0 {
-// 		err = fmt.Errorf("### It didn't work! Error code: %d", errorCode)
-// 		return "", err
-// 	}
+// GetResource TODO
+func GetResource(typeName, resourceName string) (string, error) {
+	var resultC *C.char
+	defer C.free(unsafe.Pointer(resultC))
+	typeNameC := C.CString(typeName)
+	defer C.free(unsafe.Pointer(typeNameC))
+	resourceNameC := C.CString(resourceName)
+	defer C.free(unsafe.Pointer(resourceNameC))
 
-// 	return C.GoString(*r), nil
-// }
+	ok := C.get_resource(&resultC, typeNameC, resourceNameC)
+	if ok != 0 {
+		return "", fmt.Errorf("Error thrown calling get_all_resources: %d", ok)
+	}
+	result := C.GoString(resultC)
+	return result, nil
+}

--- a/lib/inc/libral/cwrapper.hpp
+++ b/lib/inc/libral/cwrapper.hpp
@@ -7,7 +7,7 @@
 extern "C" {
 #endif
 
-uint8_t get_types(char **result);
+uint8_t get_providers(char **result);
 uint8_t get_resource(char **result, char* type_name,  char* resource_name);
 uint8_t get_resources(char **result, char* type_name);
 

--- a/lib/inc/libral/cwrapper.hpp
+++ b/lib/inc/libral/cwrapper.hpp
@@ -7,19 +7,9 @@
 extern "C" {
 #endif
 
-char* get_all(char* type_name_c);
-
-struct outcome {
-    char* result;
-    uint8_t error_code;
-};
-
-uint8_t get_all_with_err(char **resource,
-                         char *type_name);
-
-uint8_t get_types(char *types);
-
-struct outcome get_all_outcome(char* type_name_c);
+uint8_t get_types(char **result);
+uint8_t get_resource(char **result, char* type_name,  char* resource_name);
+uint8_t get_resources(char **result, char* type_name);
 
 #ifdef __cplusplus
 }

--- a/lib/src/cwrapper.cc
+++ b/lib/src/cwrapper.cc
@@ -1,19 +1,19 @@
-#include <libral/cwrapper.hpp>
-
-#include <libral/ral.hpp>
-#include <libral/emitter/json_emitter.hpp>
-
+#include <iostream>
 #include <string>
 #include <vector>
+
+#include <libral/cwrapper.hpp>
+#include <libral/ral.hpp>
+#include <libral/emitter/json_emitter.hpp>
 
 namespace lib = libral;
 
 /* TODO in GOLand:
  *
- * getTypes()(string, error) --> string == MUST serialize vector as JSON array
- * getAllResources(type) (string, error) --> string == JSON object serialized
- * getResource(type, resource) (string, error) --> string == JSON object serialized
- * getSchema(type)(string, error) --> how to derive a JSON schema??? Use JsonSchema???
+ * [x] getTypes()(string, error) --> string == MUST serialize vector as JSON array
+ * [x] getAllResources(type) (string, error) --> string == JSON object serialized
+ * [x] getResource(type, resource) (string, error) --> string == JSON object serialized
+ * [ ] getSchema(type)(string, error) --> how to derive a JSON schema??? Use JsonSchema???
  *
  */
 
@@ -31,43 +31,45 @@ static char* str_to_cstr(const std::string& s) {
 // Public interface
 //
 
-// TODO(ale): decide between pointers & structs for calling / returning
-//            conventions and use a single approach
+uint8_t get_types(char **result) {
+    std::vector<std::string> data_dirs;
+    auto ral = lib::ral::create(data_dirs);
+    auto raw_types = ral->types();
+    lib::json_emitter em {};
+    auto types = em.parse_types(raw_types);
 
-char* get_all(char* type_name)
-{
+    *result = str_to_cstr(types);
+    return 0;
+}
+
+uint8_t get_resources(char **result, char* type_name) {
     std::vector<std::string> data_dirs;
     auto ral = lib::ral::create(data_dirs);
     auto opt_type = ral->find_type(std::string(type_name));
 
     if (!opt_type)
-        return NULL;
-
-    auto results = (*opt_type)->instances();
-    lib::json_emitter em {};
-    auto resources = em.parse_list(**opt_type, results);
-    return str_to_cstr(resources);
-}
-
-// TODO(ale): make the pointer approach work
-uint8_t get_all_with_err(char **resource,
-                         char *type_name) {
-    char *tmp = get_all(type_name);
-
-    if (resource == nullptr)
         return 1;
 
-    resource = &tmp;
+    auto resource_instances = (*opt_type)->instances();
+    lib::json_emitter em {};
+    auto resources = em.parse_list(**opt_type, resource_instances);
+    *result = str_to_cstr(resources);
     return 0;
 }
 
-struct outcome get_all_outcome(char* type_name_c) {
-    char *tmp = get_all(type_name_c);
-    uint8_t e_c = (tmp != NULL) ? 0 : 1;
-    struct outcome out = {tmp, e_c};
-    return out;
-}
 
-uint8_t get_types(char *types) {
+uint8_t get_resource(char **result, char* type_name, char* resource_name) {
+    std::vector<std::string> data_dirs;
+    auto ral = lib::ral::create(data_dirs);
+    auto opt_type = ral->find_type(std::string(type_name));
+
+    if (!opt_type)
+        return 1;
+
+    auto inst = (*opt_type)->find(std::string(resource_name));
+    lib::json_emitter em {};
+
+    auto resource = em.parse_find(**opt_type, inst);
+    *result = str_to_cstr(resource);
     return 0;
 }

--- a/lib/src/cwrapper.cc
+++ b/lib/src/cwrapper.cc
@@ -31,7 +31,7 @@ static char* str_to_cstr(const std::string& s) {
 // Public interface
 //
 
-uint8_t get_types(char **result) {
+uint8_t get_providers(char **result) {
     std::vector<std::string> data_dirs;
     auto ral = lib::ral::create(data_dirs);
     auto raw_types = ral->types();


### PR DESCRIPTION
This PR switches to passing the libral JSON string by pointer in the C wrapper, also sanitises the Go wrapper and adds go docs.

The following Go functions are added:

- `GetProviders() (string, error)`
- `GetResources(typeName string) (string, error)`
- `GetResources(typeName, resourceName string) (string, error)`

**Note** external to this PR still need statically compiled dependencies for libral, also error handling in the C wrapper likely needs some love.

### TODO
- [ ] Add `libral_test.go`
